### PR TITLE
Add default value for integer fields

### DIFF
--- a/Configuration/TCA/sys_action.php
+++ b/Configuration/TCA/sys_action.php
@@ -82,7 +82,8 @@ return [
                 'size' => 10,
                 'minitems' => 0,
                 'maxitems' => 200,
-                'autoSizeMax' => 10
+                'autoSizeMax' => 10,
+                'default' => 0,
             ]
         ],
         't1_userprefix' => [
@@ -129,6 +130,7 @@ return [
                 'size' => 1,
                 'maxitems' => 1,
                 'minitems' => 1,
+                'default' => 0,
             ]
         ],
         't3_listPid' => [
@@ -140,6 +142,7 @@ return [
                 'size' => 1,
                 'maxitems' => 1,
                 'minitems' => 1,
+                'default' => 0,
             ]
         ],
         't3_tables' => [


### PR DESCRIPTION
Database strict mode makes it neccessary to add default values to integer fields in TCA configuration. Otherwise copying and pasting of action records fails.